### PR TITLE
DIG-80395 image cache

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -412,10 +412,11 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	if resp.StatusCode >= 400 {
 		if resp.StatusCode == 400 {
-			return nil, errors.ErrCustom.New("Bad Request (400) received when retrieving image.")
+			return nil, errors.ErrBadRequestReason.New(u.String())
 		}
-		return nil,
-			errors.ErrCustom.New(fmt.Sprintf("Error received when retrieving image. Status: %d", resp.StatusCode))
+		imageError := errors.ErrCustom.New(fmt.Sprintf("Error received when retrieving image: %s", u.String()))
+		imageError.SetCode(resp.StatusCode)
+		return nil, imageError
 	}
 
 	if should304(req, resp) {

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -160,7 +160,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 
 	imageRequest, _ := http.NewRequest("GET", req.String(), nil)
 	imageRequest.Header = req.Original.Header
-	resp, err :=p.Client.Do(imageRequest)
+	resp, err := p.Client.Do(imageRequest)
 	if err != nil {
 		msg := fmt.Sprintf("error fetching remote image: %v", err)
 		log.Print(msg)
@@ -403,7 +403,7 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	imageRequest, _ := http.NewRequest("GET", u.String(), nil)
 	imageRequest.Header = req.Header
 	resp, err := t.CachingClient.Do(imageRequest)
-	if err != nil {
+	if err != nil || resp.StatusCode >= 400 {
 		return nil, err
 	}
 

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -170,7 +170,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode >= 404 {
+	if resp.StatusCode >= 400 {
 		msg := fmt.Sprintf("Error Code %d received. Remote image not found: %v", resp.StatusCode, req.String())
 		log.Print(msg)
 		http.Error(w, msg, http.StatusNotFound)


### PR DESCRIPTION
Adding a 400 check since requests such as the following are getting through and corrupting the cache
<img width="1081" alt="Screenshot 2023-10-02 at 3 12 21 PM" src="https://github.com/TotalWineLabs/imageproxy/assets/9142514/79e13cbe-e7c4-43b4-aabb-c1c88ce161c7">
